### PR TITLE
Checks if URL is reachable before uploading the logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Add the following inside the application manifest (inside `<application>`):
  * **LogseneRequiresUnmeteredNetwork**: if logs should be shipped only on unmetered network connection
  * **LogseneRequiresDeviceIdle**: if logs should be shipped only when device is idle
  * **LogseneRequiresBatteryNotLow**: if logs should be shipped only when battery is not low
+ * **LogseneCheckUnreachableUrl**: checks if url is reachable before pushing logs
+ * **LogseneUnreachableUrlTimeout**: socket timout to check if url is reachable
  * **LogseneAutomaticLocationEnabled**: if logs should be automatically enriched with device location information. See the **Enriching Logs with Location** section for more details.
 
 Example Application

--- a/logseneandroid/src/main/java/com/sematext/logseneandroid/LogWorker.java
+++ b/logseneandroid/src/main/java/com/sematext/logseneandroid/LogWorker.java
@@ -102,7 +102,7 @@ public class LogWorker extends Worker {
     leftAttempts -= 1;
     try {
       Log.d(LOG_TAG, "Attempting to send bulk request");
-      if(checkUnreachableUrl && !Utils.isURLReachable(receiverUrl, unreachableUrlTimeout)){
+      if (checkUnreachableUrl && !Utils.isURLReachable(receiverUrl, unreachableUrlTimeout)){
         Log.e(LOG_TAG, "Unreachable URL");
         return attemptExecute(bulk, leftAttempts);
       }

--- a/logseneandroid/src/main/java/com/sematext/logseneandroid/Logsene.java
+++ b/logseneandroid/src/main/java/com/sematext/logseneandroid/Logsene.java
@@ -412,7 +412,7 @@ public class Logsene {
     sendRequiresBatteryNotLow = data.getBoolean("LogseneSendRequiresBatteryNotLow", false);
     automaticLocationEnabled = data.getBoolean("LogseneAutomaticLocationEnabled", false);
     checkUnreachableUrl = data.getBoolean("LogseneCheckUnreachableUrl", false);
-    unreachableUrlTimeout = (data.getInt("LogseneUnreachableUrlTimeout", DEFAULT_UNREACHABLE_TIMEOUT));
+    unreachableUrlTimeout = data.getInt("LogseneUnreachableUrlTimeout", DEFAULT_UNREACHABLE_TIMEOUT);
 
     Log.d(TAG, String.format("Logsene is configured:\n"
                     + "  Type:                                   %s\n"

--- a/logseneandroid/src/main/java/com/sematext/logseneandroid/Logsene.java
+++ b/logseneandroid/src/main/java/com/sematext/logseneandroid/Logsene.java
@@ -32,6 +32,9 @@ public class Logsene {
   public static final String KEY_APPTOKEN = "LOGSENE_APPTOKEN";
   public static final String KEY_TYPE = "LOGSENE_TYPE";
 
+  public static final String KEY_CHECK_UNREACHABLE_URL = "LOGSENE_CHECK_UNREACHABLE_URL";
+  public static final String KEY_UNREACHABLE_URL_TIMEOUT = "LOGSENE_UNREACHABLE_URL_TIMEOUT";
+  public static final int DEFAULT_UNREACHABLE_TIMEOUT = 500;
   private final String TAG = getClass().getSimpleName();
   private final String FLUSH_WORKER_TAG = "com.sematext.android.LogWorker.unconstrained";
   private final String INTERVAL_WORKER_TAG = "com.sematext.android.LogWorker.interval";
@@ -86,6 +89,8 @@ public class Logsene {
   private boolean sendRequiresBatteryNotLow;
   private boolean isActive;
   private boolean automaticLocationEnabled;
+  private boolean checkUnreachableUrl;
+  private int unreachableUrlTimeout;
   private LogseneLocationListener locationListener;
 
   // Private constructor - no instances.
@@ -406,6 +411,8 @@ public class Logsene {
     sendRequiresDeviceIdle = data.getBoolean("LogseneSendRequiresDeviceIdle", false);
     sendRequiresBatteryNotLow = data.getBoolean("LogseneSendRequiresBatteryNotLow", false);
     automaticLocationEnabled = data.getBoolean("LogseneAutomaticLocationEnabled", false);
+    checkUnreachableUrl = data.getBoolean("LogseneCheckUnreachableUrl", false);
+    unreachableUrlTimeout = (data.getInt("LogseneUnreachableUrlTimeout", DEFAULT_UNREACHABLE_TIMEOUT));
 
     Log.d(TAG, String.format("Logsene is configured:\n"
                     + "  Type:                                   %s\n"
@@ -426,6 +433,8 @@ public class Logsene {
             .putString(KEY_RECEIVERURL, receiverUrl)
             .putString(KEY_APPTOKEN, appToken)
             .putString(KEY_TYPE, type)
+            .putBoolean(KEY_CHECK_UNREACHABLE_URL, checkUnreachableUrl)
+            .putInt(KEY_UNREACHABLE_URL_TIMEOUT, unreachableUrlTimeout)
             .build();
   }
 

--- a/logseneandroid/src/main/java/com/sematext/logseneandroid/Utils.java
+++ b/logseneandroid/src/main/java/com/sematext/logseneandroid/Utils.java
@@ -6,8 +6,12 @@ import android.content.pm.PackageManager;
 
 import androidx.core.app.ActivityCompat;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -60,5 +64,24 @@ public enum Utils {
             Manifest.permission.ACCESS_COARSE_LOCATION);
     return finePermissionState == PackageManager.PERMISSION_GRANTED ||
             coarsePermissionState == PackageManager.PERMISSION_GRANTED;
+  }
+
+  /**
+   * @param url URL
+   * @param timeout for the socket connection
+   * @return <code>true</code> if url is reachable
+   */
+  public static boolean isURLReachable(String url, int timeout) {
+    try {
+      final URL u  = new URL(url);
+      final Socket socket = new Socket();
+      socket.setSoTimeout(timeout);
+      socket.connect(new InetSocketAddress(u.getHost(), 80),timeout);
+      boolean isConnected = socket.isConnected();
+      socket.close();
+      return isConnected;
+    }catch (IOException e){
+      return false;
+    }
   }
 }

--- a/logseneandroid/src/main/java/com/sematext/logseneandroid/Utils.java
+++ b/logseneandroid/src/main/java/com/sematext/logseneandroid/Utils.java
@@ -80,7 +80,7 @@ public enum Utils {
       boolean isConnected = socket.isConnected();
       socket.close();
       return isConnected;
-    }catch (IOException e){
+    } catch (IOException e){
       return false;
     }
   }


### PR DESCRIPTION
**Problem:**

We are getting multiple pager-duty incidents as` java.net.SocketTimeoutException: timeout` for the URL `https://logsene-receiver.sematext.com/_bulk`. It is happening due to network issues on the client side and the URL is unreachable.
It is taking a lot of developer time to go through the incident to identify the root cause and mark the issue as a duplicate.

**Solution:**
As a part of the fix, we are checking if the URL is reachable before we process the log uploads. This will surely take a bit more time than the regular upload. The client app will have the option to bypass the URL reachable check.
